### PR TITLE
fix[cgo]: Fix - memory allocted by cgo will not automaticlly free by gc.

### DIFF
--- a/jieba.go
+++ b/jieba.go
@@ -6,7 +6,10 @@ package gojieba
 #include "jieba.h"
 */
 import "C"
-import "unsafe"
+import (
+	"runtime"
+	"unsafe"
+)
 
 type TokenizeMode int
 
@@ -33,7 +36,7 @@ func NewJieba(paths ...string) *Jieba {
 	defer C.free(unsafe.Pointer(upath))
 	defer C.free(unsafe.Pointer(ipath))
 	defer C.free(unsafe.Pointer(spath))
-	return &Jieba{
+	jieba := &Jieba{
 		C.NewJieba(
 			dpath,
 			hpath,
@@ -42,6 +45,8 @@ func NewJieba(paths ...string) *Jieba {
 			spath,
 		),
 	}
+	runtime.SetFinalizer(jieba, (*Jieba).Free)
+	return jieba
 }
 
 func (x *Jieba) Free() {


### PR DESCRIPTION
Currently, when an object containing a jieba instance is dropped, the memory allocated to  jieba will not be freed automatically.

This Pull Request uses `runtime.SetFinalizer` to invoke `Free` and avoid memory leaking in the above cases.