### PR TITLE
feat(addwordex): AddWordEx() 支持指定权重和词性，解决原来 AddWord() 接口加词权重太低没有生效的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ func main() {
 	fmt.Println("精确模式:", strings.Join(words, "/"))
 
 	x.AddWord("比特币")
+	// `AddWordEx` 支持指定词语的权重，作为 `AddWord` 权重太低加词失败的补充。
+	// `tag` 参数可以为空字符串，也可以指定词性。
+	// x.AddWordEx("比特币", 100000, "")
 	s = "比特币"
 	words = x.Cut(s, use_hmm)
 	fmt.Println(s)

--- a/README_EN.md
+++ b/README_EN.md
@@ -53,6 +53,7 @@ func main() {
 	fmt.Println("精确模式:", strings.Join(words, "/"))
 
 	x.AddWord("比特币")
+	// x.AddWordEx("比特币", 100000, "")
 	s = "比特币"
 	words = x.Cut(s, use_hmm)
 	fmt.Println(s)

--- a/jieba.cpp
+++ b/jieba.cpp
@@ -84,6 +84,10 @@ void AddWord(Jieba x, const char* word) {
   ((cppjieba::Jieba*)x)->InsertUserWord(word);
 }
 
+void AddWordEx(Jieba x, const char* word, int freq, const char* tag) {
+  ((cppjieba::Jieba*)x)->InsertUserWord(word, freq, tag);
+}
+
 void RemoveWord(Jieba x, const char* word) {
   ((cppjieba::Jieba*)x)->DeleteUserWord(word);
 }

--- a/jieba.go
+++ b/jieba.go
@@ -103,6 +103,14 @@ func (x *Jieba) AddWord(s string) {
 	C.AddWord(x.jieba, cstr)
 }
 
+func (x *Jieba) AddWordEx(s string, freq int, tag string) {
+	cstr := C.CString(s)
+	ctag := C.CString(tag)
+	defer C.free(unsafe.Pointer(ctag))
+	defer C.free(unsafe.Pointer(cstr))
+	C.AddWordEx(x.jieba, cstr, C.int(freq), ctag)
+}
+
 func (x *Jieba) RemoveWord(s string) {
 	cstr := C.CString(s)
 	defer C.free(unsafe.Pointer(cstr))

--- a/jieba.h
+++ b/jieba.h
@@ -28,6 +28,7 @@ char** CutAll(Jieba handle, const char* sentence);
 char** CutForSearch(Jieba handle, const char* sentence, int is_hmm_used);
 char** Tag(Jieba handle, const char* sentence);
 void AddWord(Jieba handle, const char* word);
+void AddWordEx(Jieba handle, const char* word, int freq, const char* tag);
 void RemoveWord(Jieba handle, const char* word);
 
 Word* Tokenize(Jieba x, const char* sentence, TokenizeMode mode, int is_hmm_used);


### PR DESCRIPTION
fix https://github.com/yanyiwu/gojieba/issues/80
fix https://github.com/yanyiwu/gojieba/issues/27

新增 `AddWordEx(s string, freq int, tag string)` 方法，支持录入新词指定权重。

**因为自己词库的词，优先级更高，大概率要高于 WordWeightMedian。**

详细的分析过程，请参阅我的文章，如有错误，还请斧正：[解决 Gojieba 分词添加关键词 AddWord 接口不起作用的问题](https://imlht.com/archives/416/)