### PR TITLE
warning警告排除deprecated

### DIFF
--- a/jieba.go
+++ b/jieba.go
@@ -1,7 +1,7 @@
 package gojieba
 
 /*
-#cgo CXXFLAGS: -I./deps -DLOGGING_LEVEL=LL_WARNING -O3 -Wall
+#cgo CXXFLAGS: -I./deps -DLOGGING_LEVEL=LL_WARNING -O3 -Wall  -Wno-deprecated
 #include <stdlib.h>
 #include "jieba.h"
 */


### PR DESCRIPTION
不加的情况在最新版的 x86_64-w64-mingw32/12.2.0 会报如下信息：


># github.com/yanyiwu/gojieba
In file included from vendor\github.com\yanyiwu\gojieba\deps/cppjieba/DictTrie.hpp:13,
                 from vendor\github.com\yanyiwu\gojieba\deps/cppjieba/QuerySegment.hpp:8,
                 from vendor\github.com\yanyiwu\gojieba\deps/cppjieba/Jieba.hpp:4,
                 from jieba.cpp:5:
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp: In function 'std::string& limonp::LTrim(std::string&)':
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:87:93: warning: 'std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = unsigned int; _Result = bool]' is deprecated: use 'std::function' instead [-Wdeprecated-declarations]
   87 |   s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<unsigned, bool>(IsSpace))));
      |                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
In file included from E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_tree.h:65,
                 from E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/set:60,
                 from vendor\github.com\yanyiwu\gojieba\deps/cppjieba/QuerySegment.hpp:5:
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_function.h:1126:5: note: declared here
 1126 |     ptr_fun(_Result (*__x)(_Arg))
      |     ^~~~~~~
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:87:64: warning: 'constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = pointer_to_unary_function<unsigned int, bool>]' is deprecated: use 'std::not_fn' instead [-Wdeprecated-declarations]
   87 |   s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<unsigned, bool>(IsSpace))));
      |                                                       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_function.h:1046:5: note: declared here
 1046 |     not1(const _Predicate& __pred)
      |     ^~~~
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp: In function 'std::string& limonp::RTrim(std::string&)':
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:92:84: warning: 'std::pointer_to_unary_function<_Arg, _Result> std::ptr_fun(_Result (*)(_Arg)) [with _Arg = unsigned int; _Result = bool]' is deprecated: use 'std::function' instead [-Wdeprecated-declarations]
   92 |   s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<unsigned, bool>(IsSpace))).base(), s.end());
      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_function.h:1126:5: note: declared here
 1126 |     ptr_fun(_Result (*__x)(_Arg))
      |     ^~~~~~~
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:92:55: warning: 'constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = pointer_to_unary_function<unsigned int, bool>]' is deprecated: use 'std::not_fn' instead [-Wdeprecated-declarations]
   92 |   s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<unsigned, bool>(IsSpace))).base(), s.end());
      |                                              ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_function.h:1046:5: note: declared here
 1046 |     not1(const _Predicate& __pred)
      |     ^~~~
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp: In function 'std::string& limonp::LTrim(std::string&, char)':
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:101:77: warning: 'std::binder2nd<_Operation> std::bind2nd(const _Operation&, const _Tp&) [with _Operation = equal_to<char>; _Tp = char]' is deprecated: use 'std::bind' instead [-Wdeprecated-declarations]
  101 |   s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::bind2nd(std::equal_to<char>(), x))));
      |                                                                 ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_function.h:1438:
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/backward/binders.h:172:5: note: declared here
  172 |     bind2nd(const _Operation& __fn, const _Tp& __x)
      |     ^~~~~~~
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:101:64: warning: 'constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = binder2nd<equal_to<char> >]' is deprecated: use 'std::not_fn' instead [-Wdeprecated-declarations]
  101 |   s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::bind2nd(std::equal_to<char>(), x))));
      |                                                       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_function.h:1046:5: note: declared here
 1046 |     not1(const _Predicate& __pred)
      |     ^~~~
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp: In function 'std::string& limonp::RTrim(std::string&, char)':
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:106:68: warning: 'std::binder2nd<_Operation> std::bind2nd(const _Operation&, const _Tp&) [with _Operation = equal_to<char>; _Tp = char]' is deprecated: use 'std::bind' instead [-Wdeprecated-declarations]
  106 |   s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::bind2nd(std::equal_to<char>(), x))).base(), s.end());
      |                                                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/backward/binders.h:172:5: note: declared here
  172 |     bind2nd(const _Operation& __fn, const _Tp& __x)
      |     ^~~~~~~
vendor\github.com\yanyiwu\gojieba\deps/limonp/StringUtil.hpp:106:55: warning: 'constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = binder2nd<equal_to<char> >]' is deprecated: use 'std::not_fn' instead [-Wdeprecated-declarations]
  106 |   s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::bind2nd(std::equal_to<char>(), x))).base(), s.end());
      |                                              ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
E:/soft/mingw64/lib/gcc/x86_64-w64-mingw32/12.2.0/include/c++/bits/stl_function.h:1046:5: note: declared here
 1046 |     not1(const _Predicate& __pred)

新增  -Wno-deprecated  后即可隐藏 