### PR TITLE
Test current Go versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,19 +15,25 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [
-          ubuntu-latest, 
-          macos-latest,
-          windows-latest,
-        ]  
-        go-version: ['1.20', '1.21', '1.22', '1.23']
-        # See supported Go release schedule at https://golang.org/doc/devel/release.html
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        go-version:
+          - '1.20'
+          - '1.21'
+          - '1.22'
+          - '1.23'
+          - '1.24'
+          - '1.25'
+          - '1.26'
+        # See supported Go release schedule at https://go.dev/doc/devel/release
         # https://github.com/actions/go-versions/blob/main/versions-manifest.json
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         # See supported Go release schedule at https://go.dev/doc/devel/release
         # https://github.com/actions/go-versions/blob/main/versions-manifest.json
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary
- add Go 1.24, 1.25, and 1.26 to the GitHub Actions test matrix
- update `actions/checkout` to v6 and `actions/setup-go` to v6
- keep existing older Go versions in the matrix to preserve current compatibility signal

## Context
- Go downloads currently list Go 1.26.2 and Go 1.25.9 as stable versions.
- `setup-go@v6` supports the current Go version syntax and Node 24 action runtime.

## Testing
- Not run locally; workflow-only change.