### PR TITLE
[codex] Test supported Go versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,6 @@ jobs:
           - macos-latest
           - windows-latest
         go-version:
-          - '1.20'
-          - '1.21'
-          - '1.22'
-          - '1.23'
-          - '1.24'
           - '1.25'
           - '1.26'
         # See supported Go release schedule at https://go.dev/doc/devel/release


### PR DESCRIPTION
## Summary

- Remove EOL Go 1.20, 1.21, 1.22, 1.23, and 1.24 from the GitHub Actions matrix.
- Keep CI coverage on currently supported Go releases: 1.25 and 1.26.

## Rationale

The Go release policy supports each major release until there are two newer major releases. With Go 1.26 current, the supported Go release lines are 1.25 and 1.26, so older CI jobs no longer provide supported-runtime coverage.

## Validation

- `env GOCACHE=/tmp/go-build-cache go test ./...` with local Go 1.26.1

Note: local `git push` returned HTTP 403 for the available credentials, so the branch commit was published through the GitHub connector git object API.